### PR TITLE
Sanitize URLs with that contain spaces

### DIFF
--- a/vripper-server/src/main/java/tn/mnlr/vripper/services/ConnectionManager.java
+++ b/vripper-server/src/main/java/tn/mnlr/vripper/services/ConnectionManager.java
@@ -54,13 +54,13 @@ public class ConnectionManager {
     }
 
     public HttpGet buildHttpGet(String url) {
-        HttpGet httpGet = new HttpGet(url);
+        HttpGet httpGet = new HttpGet(url.replace(" ", "+"));
         httpGet.addHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36");
         return httpGet;
     }
 
     public HttpPost buildHttpPost(String url) {
-        HttpPost httpPost = new HttpPost(url);
+        HttpPost httpPost = new HttpPost(url.replace(" ", "+"));
         httpPost.addHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36");
         return httpPost;
     }


### PR DESCRIPTION
Once in awhile I run into a set with non-encoded spaces in the image URL.

The UI handles them just fine, but java needs them replaced or else it chokes.