### PR TITLE
Experimental: Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM maven:3.8.1-jdk-11-slim AS build
+
+RUN mkdir /build
+COPY . /build
+
+WORKDIR /build
+RUN mvn package -Dmaven.test.skip=true -T 2C
+
+
+FROM openjdk:11.0.11-jre-slim AS run
+
+ARG VERSION
+ENV VERSION=${VERSION:-unspecified}
+ENV JAR_FILE=vripper-server-${VERSION}-web.jar
+ENV VRIPPER_DIR=/vripper
+
+RUN mkdir ${VRIPPER_DIR}
+COPY --from=build /build/vripper-server/target/${JAR_FILE} ${VRIPPER_DIR}
+WORKDIR ${VRIPPER_DIR}
+RUN mkdir downloads
+
+EXPOSE 8080/tcp
+
+CMD java -Dbase.dir.name=base -Duser.home=${VRIPPER_DIR}/downloads -jar ${VRIPPER_DIR}/${JAR_FILE}

--- a/README-docker.md
+++ b/README-docker.md
@@ -1,0 +1,37 @@
+# VRipper! In Docker!
+
+_WARNING_: This is experimental. Not familiar with Docker? This isn't for you, yet.
+
+Java is nice. Java is cross-platform. But, it can be a challenge for people unfamiliar with Java to run and use an app built it. Docker can help.
+
+## How to build
+
+You need a recent version of Docker (tested with `20.10.2`).
+
+The [`Dockerfile`](Dockerfile) will build the VRipper _Server_ app and then build it into a Docker image.
+
+To build the server app as a Docker image:
+
+    docker build --build-arg VERSION=3.5.4 --tag=death-claw/vripper-project:3.5.4 --file=Dockerfile .
+
+## How to run
+
+You could use `docker run` but `docker-compose` makes it more convenient. You need a recent version of `docker-compose` (tested with `1.25.0`).
+
+Change ports and volumes in [`docker-compose.yml`](docker-compose.yml) if necessary. Then, to run the server app container in the background:
+
+    docker-compose up --detach
+
+## How to use
+
+Use the Server app as you would, normally. See [`README.md`](README.md).
+
+## Future
+
+If **death-claw** wishes:
+
+- Run VRipper in container as non-root user.
+- Resolve non-root user file permissions.
+- Automatically build and tag a Docker image for each tagged version of VRipper.
+- Push images to the GitHub Packages Docker registry.
+- Write end-user instructions for running images pulled from GitHub registry.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+
+  vripper:
+    container_name: vripper
+    image: death-claw/vripper-project:3.5.4
+    ports:
+      - "8080:8080/tcp"
+    volumes:
+      - "./base:/vripper/base"
+      - "./downloads:/vripper/downloads"
+    restart: "unless-stopped"

--- a/vripper-server/src/main/java/tn/mnlr/vripper/download/DownloadService.java
+++ b/vripper-server/src/main/java/tn/mnlr/vripper/download/DownloadService.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 @Slf4j
 public class DownloadService {
 
-  private final int MAX_POOL_SIZE = 12;
+  private final int MAX_POOL_SIZE = 16;
 
   private final SettingsService settingsService;
   private final DataService dataService;

--- a/vripper-server/src/main/java/tn/mnlr/vripper/services/ConnectionService.java
+++ b/vripper-server/src/main/java/tn/mnlr/vripper/services/ConnectionService.java
@@ -118,7 +118,7 @@ public class ConnectionService {
     HttpGet httpGet = new HttpGet(url.replace(" ", "+"));
     httpGet.addHeader(
         "User-Agent",
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36");
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.67");
     addToContext(context, httpGet);
     return httpGet;
   }
@@ -127,7 +127,7 @@ public class ConnectionService {
     HttpPost httpPost = new HttpPost(url.replace(" ", "+"));
     httpPost.addHeader(
         "User-Agent",
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36");
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.67");
     addToContext(context, httpPost);
     return httpPost;
   }
@@ -136,7 +136,7 @@ public class ConnectionService {
     HttpGet httpGet = new HttpGet(uri);
     httpGet.addHeader(
         "User-Agent",
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36");
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.67");
     addToContext(context, httpGet);
     return httpGet;
   }

--- a/vripper-server/src/main/java/tn/mnlr/vripper/services/SettingsService.java
+++ b/vripper-server/src/main/java/tn/mnlr/vripper/services/SettingsService.java
@@ -247,10 +247,10 @@ public class SettingsService {
           String.format("%s is not a directory", settings.getDownloadPath()));
     }
 
-    if (settings.getMaxTotalThreads() < 0 || settings.getMaxTotalThreads() > 12) {
+    if (settings.getMaxTotalThreads() < 0 || settings.getMaxTotalThreads() > 16) {
       throw new ValidationException(
           String.format(
-              "Invalid max global concurrent download settings, values must be in [%d,%d]", 0, 12));
+              "Invalid max global concurrent download settings, values must be in [%d,%d]", 0, 16));
     }
 
     if (settings.getMaxThreads() < 1 || settings.getMaxThreads() > 4) {

--- a/vripper-ui/src/app/settings/settings.component.html
+++ b/vripper-ui/src/app/settings/settings.component.html
@@ -86,7 +86,7 @@
               <input
                 formControlName="maxTotalThreads"
                 matInput
-                max="12"
+                max="16"
                 min="0"
                 name="maxTotalThreads"
                 placeholder="Global concurrent downloads"


### PR DESCRIPTION
Thank you for _VRipper_. I notice you often support users' Java issues. This may help you and them.

 Just a start.

- `Dockerfile` for building _VRipper Server app_ as a Docker image.
- `docker-compose.yml` for running _VRipper Server app_ image as a Docker container.

Future, if @death-claw wishes:
- Run VRipper in container as non-root user.
- Resolve non-root user file permissions.
- Automatically build and tag a Docker image for each tagged version of VRipper.
- Push images to the GitHub Packages Docker registry.
- Write end-user instructions for running images pulled from GitHub registry.
