### PR TITLE
Fix for images on Pimpandhost throwing exception

### DIFF
--- a/vripper-core/src/main/kotlin/me/mnlr/vripper/host/PimpandhostHost.kt
+++ b/vripper-core/src/main/kotlin/me/mnlr/vripper/host/PimpandhostHost.kt
@@ -31,7 +31,7 @@ class PimpandhostHost(
     ): Pair<String, String> {
         val newUrl: String
         try {
-            newUrl = appendUri(url.replace("http://", "https://"), "size=original")
+            newUrl = appendUri(url.replace("http://", "https://").replace("-medium(\\.html)?".toRegex(), ""), "size=original")
         } catch (e: Exception) {
             throw HostException(e)
         }


### PR DESCRIPTION
Attempts to fix the following exception:
﻿

Failed to download http://pimpandhost.com/image/39446205-medium.html me.mnlr.vripper.exception. DownloadException: me.mnlr.vripper.exception.HostException: Xpath //img[contains(@class, 'original')]' cannot be found in 'http://pimpandhost.com/image/39446205-medium.html' at me.mnlr.vripper.download.ImageDownloadRunnable.download(Image Download Runnable.kt:88) at me.mnlr.vripper.download.ImageDownloadRunnable.run(ImageDownloadRunnable.kt:151) at net.jodah.failsafe.Functions.lambda$toSupplier$10(Functions.java:262) at net.jodah.failsafe.Functions.lambda$get$0(Functions.java:48) at net.jodah.failsafe.Retry Policy Executor.lambda$supply$0(RetryPolicyExecutor.java:66) at net.jodah.failsafe.Execution.executeSync(Execution.java:128) at net.jodah.failsafe.FailsafeExecutor.call(FailsafeExecutor.java:379) at net.jodah.failsafe.FailsafeExecutor.run(FailsafeExecutor.java:212) at me.mnlr.vripper.download.DownloadService.schedule$lambda$28 (DownloadService.kt:264) at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) at java.base/java.lang.Thread.run(Unknown Source)
Caused by: me.mnlr.vripper.exception.HostException: Xpath //img[contains(@class, 'original')]' cannot be found in 'http://pimpandhost.com/image/39446205-medium.html' at me.mnlr.vripper.host.PimpandhostHost.resolve(PimpandhostHost.kt:46) at me.mnlr.vripper.host.Host.download Internal(Host.kt:62) at me.mnlr.vripper.download.ImageDownloadRunnable.download (ImageDownloadRunnable.kt:72) 11 more