### PR TITLE
Fix open file directory on Linux when the path contains spaces

### DIFF
--- a/vripper-gui/src/main/kotlin/me/vripper/gui/utils/CommonUtils.kt
+++ b/vripper-gui/src/main/kotlin/me/vripper/gui/utils/CommonUtils.kt
@@ -8,7 +8,7 @@ fun openFileDirectory(path: String) {
     if(os.contains("Windows")) {
         Shell32.INSTANCE.ShellExecuteW(null, WString("open"), WString(path), null, null, 1)
     } else if(os.contains("Linux")) {
-        Runtime.getRuntime().exec("xdg-open $path")
+        Runtime.getRuntime().exec(arrayOf("xdg-open", path))
     } else if(os.contains("Mac")) {
         Runtime.getRuntime().exec("open -R $path")
     }


### PR DESCRIPTION
Tested on Arch + KDE. 
Choosing "Opening containing folder" doesn't open Dolphin. It seems that path with spaces lead to this issue. Using the non-deprecated version of the function with an array of strings as args solves the problem.

Fix https://github.com/dev-claw/vripper-project/issues/281